### PR TITLE
change function signature and provide documentation

### DIFF
--- a/lib/coo.cpp
+++ b/lib/coo.cpp
@@ -1,7 +1,42 @@
-#include "coo.hpp"
 #include <algorithm>
 
 namespace bmm_lib {
+  /**
+   * Compute B = A for COO matrix A, CSR matrix B
+   *
+   *
+   * Input Arguments:
+   *   I  n_row      - number of rows in A
+   *   I  n_col      - number of columns in A
+   *   I  nnz        - number of nonzeros in A
+   *   I  Ai[nnz(A)] - row indices
+   *   I  Aj[nnz(A)] - column indices
+   *   T  Ax[nnz(A)] - nonzeros
+   * Output Arguments:
+   *   I Bp  - row pointer
+   *   I Bj  - column indices
+   *   T Bx  - nonzeros
+   *
+   * Note:
+   *   Output arrays Bp, Bj, and Bx must be preallocated
+   *
+   * Note:
+   *   Input:  row and column indices *are not* assumed to be ordered
+   *
+   *   Note: duplicate entries are carried over to the CSR representation
+   *
+   *   Complexity: Linear.  Specifically O(nnz(A) + max(n_row,n_col))
+   *
+   * @param n_row number of rows in A
+   * @param n_col number of columns in A
+   * @param nnz number of non zeros in A
+   * @param Ai row indices
+   * @param Aj column indices
+   * @param Ax non zeros
+   * @param Bp row indices
+   * @param Bj column indices
+   * @param Bx non zeros
+   */
   template<class I, class T>
   void coo_to_csr(const I n_row, const I n_col, const I nnz, const I Ai[],
 				  const I Aj[], const T Ax[], I Bp[], I Bj[], T Bx[]) {
@@ -40,9 +75,45 @@ namespace bmm_lib {
 	// now Bp,Bj,Bx form a CSR representation (with possible duplicates)
   }
 
+  /**
+   * Compute B = A for COO matrix A, CSC matrix B
+   *
+   *
+   * Input Arguments:
+   *   I  n_row      - number of rows in A
+   *   I  n_col      - number of columns in A
+   *   I  nnz        - number of nonzeros in A
+   *   I  Ai[nnz(A)] - row indices
+   *   I  Aj[nnz(A)] - column indices
+   *   T  Ax[nnz(A)] - nonzeros
+   * Output Arguments:
+   *   I Bp  - row pointer
+   *   I Bj  - column indices
+   *   T Bx  - nonzeros
+   *
+   * Note:
+   *   Output arrays Bp, Bj, and Bx must be preallocated
+   *
+   * Note:
+   *   Input:  row and column indices *are not* assumed to be ordered
+   *
+   *   Note: duplicate entries are carried over to the CSC representation
+   *
+   *   Complexity: Linear.  Specifically O(nnz(A) + max(n_row,n_col))
+   *
+   * @param n_row number of rows in A
+   * @param n_col number of columns in A
+   * @param nnz number of non zeros in A
+   * @param Ai row indices
+   * @param Aj column indices
+   * @param Ax non zeros
+   * @param Bp row indices
+   * @param Bj column indices
+   * @param Bx non zeros
+   */
   template<class I, class T>
-  void coo_to_csc(const I n_row, const I n_col, const I nnz, const I Ai[],
-				  const I Aj[], const T Ax[], I Bp[], I Bi[], T Bx[]) {
+  void coo_to_csc(const I n_row, const I n_col, const I nnz, const I *Ai,
+				  const I *Aj, const T *Ax, I *Bp, I *Bi, T *Bx) {
 	coo_to_csr<I, T>(n_col, n_row, nnz, Aj, Ai, Ax, Bp, Bi, Bx);
   }
 } // namespace bmm_lib

--- a/lib/coo.hpp
+++ b/lib/coo.hpp
@@ -41,8 +41,10 @@ namespace bmm_lib {
 				  const I Aj[], const T Ax[], I Bp[], I Bj[], T Bx[]);
 
   template<class I, class T>
-  void coo_to_csc(const I n_row, const I n_col, const I nnz, const I Ai[],
-				  const I Aj[], const T Ax[], I Bp[], I Bi[], T Bx[]);
+  void coo_to_csc(const I n_row, const I n_col, const I nnz, const I *Ai,
+				  const I *Aj, const T *Ax, I *Bp, I *Bi, T *Bx);
+
 } // namespace bmm_lib
+#include "coo.cpp"
 
 #endif // SPARSE_BOOLEAN_MATRIX_MULTIPLICATION_COO_HPP


### PR DESCRIPTION
This changes the function signature and instead of expecting an array pointer, it expects a pointer of the same type. This was changed so that getting data from a vector could be easier by just using `vector.data()`

Also some documentation was added for the coo header library so that identifying parameters could be easier